### PR TITLE
Add workflow that builds & deploys examples and docs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -43,9 +43,9 @@ jobs:
           git clone https://github.com/qojulia/QuantumOptics.jl-documentation
 
       - name: 'Build examples'
+        working-directory: ./QuantumOptics.jl-examples
         run: |
           set -v
-          cd ./QuantumOptics.jl-examples
           julia -e '
           using Pkg
           Pkg.activate(".")
@@ -57,9 +57,9 @@ jobs:
           include("make.jl")
           '
       - name: 'Build docs'
+        working-directory: ./QuantumOptics.jl-documentation
         run: |
           set -v
-          cd ../QuantumOptics.jl-documentation
           julia -e '
           using Pkg
           Pkg.activate(".")

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -69,7 +69,6 @@ jobs:
           using Pkg
           Pkg.activate(".")
           Pkg.instantiate()
-          print(readdir())
           include("make.jl")
           '
 
@@ -80,5 +79,5 @@ jobs:
             server: ${{ secrets.ftp_server_url }}
             username: ${{ secrets.ftp_user }}
             password: ${{ secrets.ftp_password }}
-            local-dir: ./build/  # TODO or is that ./QuantumOptics.jl-documentation/build/ ?
+            local-dir: ./build/
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: 'Build examples'
         working-directory: ./examples-repo
+        env:
+          TARGETPATH_EXAMPLES: ../src/examples
         run: |
           julia -e '
           using Pkg

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,10 +1,6 @@
 name: Documentation Build
 
-# read-only repo token
-# no access to secrets
-# TODO change trigger to manual after testing
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -51,9 +51,9 @@ jobs:
           Pkg.build("PyCall")
           Pkg.add("IJulia")
           Pkg.build("IJulia")
-          print(readdir())
-          include("make.jl")
+          print(readdir("notebooks"))
           '
+          julia make.jl
 
       - name: 'Build docs'
         run: |

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -11,19 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
-      matrix:
-        pkg: [
-            "qojulia/QuantumOptics.jl"
-        ]
-        pkgversion: [latest]
-        examples_repo: [
-          "qojulia/QuantumOptics.jl-examples"
-        ]
-        docs_repo: [
-            "qojulia/QuantumOptics.jl-documentation"
-        ]
-       
+      fail-fast: false       
 
     steps:
       - uses: actions/checkout@v4
@@ -46,10 +34,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
 
       # Build examples and then docs
-      - name: 'Build'
-        env:
-          URL: ${{ matrix.pkg }}
-          VERSION: ${{ matrix.pkgversion }}
+      - name: 'Clone repos'
         run: |
           set -v
           mkdir -p ./pr
@@ -57,16 +42,23 @@ jobs:
           git clone https://github.com/qojulia/QuantumOptics.jl-examples
           git clone https://github.com/qojulia/QuantumOptics.jl-documentation
 
-          # build examples
-          cd QuantumOptics.jl-examples
+      - name: 'Build examples'
+        run: |
+          set -v
+          cd ./QuantumOptics.jl-examples
           julia -e '
           using Pkg
           Pkg.activate(".")
           Pkg.instantiate()
+          Pkg.add("PyCall")
+          Pkg.build("PyCall")
+          Pkg.add("IJulia")
+          Pkg.build("IJulia")
           include("make.jl")
           '
-
-          # build docs
+      - name: 'Build docs'
+        run: |
+          set -v
           cd ../QuantumOptics.jl-documentation
           julia -e '
           using Pkg

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install jupyter
-        run: python -m pip install jupyter nbconvert nbformat
+        run: python -m pip install jupyter nbconvert nbformat matplotlib
 
       # Install Julia
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,86 @@
+name: Documentation Build
+
+# read-only repo token
+# no access to secrets
+# TODO change trigger to manual after testing
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg: [
+            "qojulia/QuantumOptics.jl"
+        ]
+        pkgversion: [latest]
+        examples_repo: [
+          "qojulia/QuantumOptics.jl-examples"
+        ]
+        docs_repo: [
+            "qojulia/QuantumOptics.jl-documentation"
+        ]
+       
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install Julia
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: 1
+          arch: x64
+      - uses: actions/cache@v3
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+
+      # Build examples and then docs
+      - name: 'Build'
+        env:
+          URL: ${{ matrix.pkg }}
+          VERSION: ${{ matrix.pkgversion }}
+        run: |
+          set -v
+          mkdir -p ./pr
+          echo "${{ github.event.number }}" > ./pr/NR
+          git clone https://github.com/qojulia/QuantumOptics.jl-examples
+          git clone https://github.com/qojulia/QuantumOptics.jl-documentation
+
+          # build examples
+          cd QuantumOptics.jl-examples
+          julia -e '
+          using Pkg
+          Pkg.activate(".")
+          Pkg.instantiate()
+          include("make.jl")
+          '
+
+          # build docs
+          cd ../QuantumOptics.jl-documentation
+          julia -e '
+          using Pkg
+          Pkg.activate(".")
+          Pkg.instantiate()
+          include("make.jl")
+          '
+
+      # Push to complete build of documentation to FTP server
+      - name: 'Deploy'
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
+        with:
+            server: ${{ secrets.ftp_server_url }}
+            username: ${{ secrets.ftp_user }}
+            password: ${{ secrets.ftp_password }}
+            local-dir: ./build/  # TODO or is that ./QuantumOptics.jl-documentation/build/ ?
+

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -35,18 +35,12 @@ jobs:
 
       # Build examples and then docs
       - name: 'Clone repos'
-        run: |
-          set -v
-          mkdir -p ./pr
-          echo "${{ github.event.number }}" > ./pr/NR
-          git clone https://github.com/qojulia/QuantumOptics.jl-examples
-          git clone https://github.com/qojulia/QuantumOptics.jl-documentation
+        run: git clone https://github.com/qojulia/QuantumOptics.jl-examples
 
       - name: 'Build examples'
         working-directory: ./QuantumOptics.jl-examples
         run: |
           pwd
-          set -v
           julia -e '
           pwd()
           using Pkg
@@ -63,7 +57,6 @@ jobs:
       - name: 'Build docs'
         working-directory: ./QuantumOptics.jl-documentation
         run: |
-          set -v
           julia -e '
           using Pkg
           Pkg.activate(".")

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -16,12 +16,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Install jupyter-notebook
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install jupyter
+        run: python -m pip install jupyter nbconvert nbformat
+
       # Install Julia
       - uses: julia-actions/setup-julia@v1
         with:
           version: 1
           arch: x64
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -51,9 +58,8 @@ jobs:
           Pkg.build("PyCall")
           Pkg.add("IJulia")
           Pkg.build("IJulia")
-          print(readdir("notebooks"))
+          include("make.jl")
           '
-          julia make.jl
 
       - name: 'Build docs'
         run: |

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -34,15 +34,16 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
 
       # Build examples and then docs
-      - name: 'Clone repos'
-        run: git clone https://github.com/qojulia/QuantumOptics.jl-examples
+      - name: 'Checkout examples repo'
+        uses: actions/checkout@v4
+        with:
+          repository: qojulia/QuantumOptics.jl-examples
+          path: './examples-repo'
 
       - name: 'Build examples'
-        working-directory: ./QuantumOptics.jl-examples
+        working-directory: ./examples-repo
         run: |
-          pwd
           julia -e '
-          pwd()
           using Pkg
           Pkg.activate(".")
           Pkg.instantiate()
@@ -50,17 +51,17 @@ jobs:
           Pkg.build("PyCall")
           Pkg.add("IJulia")
           Pkg.build("IJulia")
-          pwd()
-          readdir()
+          print(readdir())
           include("make.jl")
           '
+
       - name: 'Build docs'
-        working-directory: ./QuantumOptics.jl-documentation
         run: |
           julia -e '
           using Pkg
           Pkg.activate(".")
           Pkg.instantiate()
+          print(readdir())
           include("make.jl")
           '
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -45,8 +45,10 @@ jobs:
       - name: 'Build examples'
         working-directory: ./QuantumOptics.jl-examples
         run: |
+          pwd
           set -v
           julia -e '
+          pwd()
           using Pkg
           Pkg.activate(".")
           Pkg.instantiate()
@@ -54,6 +56,8 @@ jobs:
           Pkg.build("PyCall")
           Pkg.add("IJulia")
           Pkg.build("IJulia")
+          pwd()
+          readdir()
           include("make.jl")
           '
       - name: 'Build docs'

--- a/make.jl
+++ b/make.jl
@@ -74,7 +74,9 @@ makedocs(
     format=Documenter.HTML(
         edit_link = nothing,
         canonical = "https://docs.qojulia.org/",
-        assets = [asset("assets/favicon.png", class=:ico, islocal = true)]
+        assets = [asset("assets/favicon.png", class=:ico, islocal = true)],
+        size_threshold = 400 * 2^10,
+        size_threshold_warn = 300 * 2^10,
         ),
     build = builddir,
     sitename = "QuantumOptics.jl",

--- a/src/api.md
+++ b/src/api.md
@@ -117,6 +117,10 @@ randoperator
 ```
 
 ```@docs
+randunitary_haar
+```
+
+```@docs
 spre
 ```
 
@@ -815,6 +819,10 @@ phase_average
 
 ```@docs
 passive_state
+```
+
+```@docs
+randstate_haar
 ```
 
 ## [Pauli](@id API: Pauli)

--- a/src/quantumobjects/operators.md
+++ b/src/quantumobjects/operators.md
@@ -66,7 +66,7 @@ mutable struct Operator{BL<:Basis,BR<:Basis,T} <: AbstractOperator{BL,BR}
 end
 ```
 
-where the data field can be any type that implements Julia's [AbstractArray interace](https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-array-1).
+where the data field can be any type that implements Julia's [AbstractArray interface](https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-array-1).
 
 The [`DenseOperator`](@ref) function can be used to construct an [`Operator`](@ref) with a dense array data field, or convert other types of operators to such a type.
 Similarly, one can use the [`SparseOperator`](@ref) function to construct an [`Operator`](@ref) with a sparse data field, and convert other types of operators. Also, a method for [`sparse(::AbstractOperator)`](@ref) is provided for conversion.


### PR DESCRIPTION
Will certainly take some back and forth in order for this to work properly, but in the end this should

* clone the [examples repo](https://github.com/qojulia/QuantumOptics.jl-examples)
* clone the docs repo (this one)
* install the latest QuantumOptics.jl release
* build the examples
* build the docs
* deploy the result on our website